### PR TITLE
SPC-2793 - Fix conversion of delta with tabs

### DIFF
--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -427,9 +427,13 @@ var OpToHtmlConverter = (function () {
             attrs = [];
         }
         endTags.reverse();
+        var content = this.getContent();
+        if (content.includes('\t')) {
+            content = "<span style=\"white-space:pre\">" + content + "</span>";
+        }
         return {
             openingTag: beginTags.join(''),
-            content: this.getContent(),
+            content: content,
             closingTag: endTags.join('')
         };
     };

--- a/dist/commonjs/OpToHtmlConverter.js
+++ b/dist/commonjs/OpToHtmlConverter.js
@@ -79,9 +79,13 @@ var OpToHtmlConverter = (function () {
             attrs = [];
         }
         endTags.reverse();
+        var content = this.getContent();
+        if (content.includes('\t')) {
+            content = "<span style=\"white-space:pre\">" + content + "</span>";
+        }
         return {
             openingTag: beginTags.join(''),
-            content: this.getContent(),
+            content: content,
             closingTag: endTags.join('')
         };
     };

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -119,10 +119,14 @@ class OpToHtmlConverter {
          attrs = [];
       }
       endTags.reverse();
+      let content = this.getContent();
+      if (content.includes('\t')) {
+         content = `<span style="white-space:pre">${content}</span>`;
+      }
 
       return {
          openingTag: beginTags.join(''),
-         content: this.getContent(),
+         content: content,
          closingTag: endTags.join('')
       };
    }

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -76,6 +76,13 @@ describe('QuillDeltaToHtmlConverter', function () {
          assert.equal(html, '<p>Text with some&nbsp; &nbsp;spaces<br/>&nbsp;one more&nbsp;</p>', html);
       });
 
+      it('should render html with tabs', function () {
+         var qdc = new QuillDeltaToHtmlConverter([{insert: "Text with\t some\t\t\tspaces"},{insert: "\n"}, {insert: "\tone more "}]);
+
+         var html = qdc.convert();
+         assert.equal(html, '<p><span style="white-space:pre">Text with\t some\t\t\tspaces</span><br/><span style="white-space:pre">\tone more </span></p>', html);
+      });
+
       it('should render mention', function () {
          let ops = [
             {


### PR DESCRIPTION
In Delta we can have tabs as plain symbols. They won't work like this in html. The only way for them to work in html is to wrap in white-space pre style.