### PR TITLE
SPA-1804: add height and alt to image

### DIFF
--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -233,9 +233,9 @@ var OpAttributeSanitizer = (function () {
             'blockquote', 'code-block', 'renderAsBlock'
         ];
         var colorAttrs = ['background', 'color'];
-        var font = dirtyAttrs.font, size = dirtyAttrs.size, link = dirtyAttrs.link, script = dirtyAttrs.script, list = dirtyAttrs.list, header = dirtyAttrs.header, align = dirtyAttrs.align, direction = dirtyAttrs.direction, indent = dirtyAttrs.indent, mentions = dirtyAttrs.mentions, mention = dirtyAttrs.mention, width = dirtyAttrs.width, target = dirtyAttrs.target, rel = dirtyAttrs.rel;
+        var font = dirtyAttrs.font, size = dirtyAttrs.size, link = dirtyAttrs.link, script = dirtyAttrs.script, list = dirtyAttrs.list, header = dirtyAttrs.header, align = dirtyAttrs.align, direction = dirtyAttrs.direction, indent = dirtyAttrs.indent, mentions = dirtyAttrs.mentions, mention = dirtyAttrs.mention, width = dirtyAttrs.width, height = dirtyAttrs.height, alt = dirtyAttrs.alt, target = dirtyAttrs.target, rel = dirtyAttrs.rel;
         var sanitizedAttrs = ['font', 'size', 'link', 'script', 'list', 'header', 'align',
-            'direction', 'indent', 'mentions', 'mention', 'width',
+            'direction', 'indent', 'mentions', 'mention', 'width', 'height', 'alt',
             'target', 'rel'
         ];
         booleanAttrs.forEach(function (prop) {
@@ -260,6 +260,12 @@ var OpAttributeSanitizer = (function () {
         }
         if (width) {
             cleanAttrs.width = width;
+        }
+        if (height) {
+            cleanAttrs.height = height;
+        }
+        if (alt) {
+            cleanAttrs.alt = alt;
         }
         if (list && OpAttributeSanitizer.IsValidList(list)) {
             cleanAttrs.list = list;
@@ -517,6 +523,8 @@ var OpToHtmlConverter = (function () {
         var tagAttrs = classes.length ? [makeAttr('class', classes.join(' '))] : [];
         if (this.op.isImage()) {
             this.op.attributes.width && (tagAttrs = tagAttrs.concat(makeAttr('width', this.op.attributes.width)));
+            this.op.attributes.height && (tagAttrs = tagAttrs.concat(makeAttr('height', this.op.attributes.height)));
+            this.op.attributes.alt && (tagAttrs = tagAttrs.concat(makeAttr('alt', this.op.attributes.alt)));
             return tagAttrs.concat(makeAttr('src', this.op.insert.value));
         }
         if (this.op.isACheckList()) {

--- a/dist/commonjs/OpAttributeSanitizer.d.ts
+++ b/dist/commonjs/OpAttributeSanitizer.d.ts
@@ -6,6 +6,8 @@ interface IOpAttributes {
     font?: string | undefined;
     size?: string | undefined;
     width?: string | undefined;
+    height?: string | undefined;
+    alt?: string | undefined;
     link?: string | undefined;
     bold?: boolean | undefined;
     italic?: boolean | undefined;

--- a/dist/commonjs/OpAttributeSanitizer.js
+++ b/dist/commonjs/OpAttributeSanitizer.js
@@ -17,9 +17,9 @@ var OpAttributeSanitizer = (function () {
             'blockquote', 'code-block', 'renderAsBlock'
         ];
         var colorAttrs = ['background', 'color'];
-        var font = dirtyAttrs.font, size = dirtyAttrs.size, link = dirtyAttrs.link, script = dirtyAttrs.script, list = dirtyAttrs.list, header = dirtyAttrs.header, align = dirtyAttrs.align, direction = dirtyAttrs.direction, indent = dirtyAttrs.indent, mentions = dirtyAttrs.mentions, mention = dirtyAttrs.mention, width = dirtyAttrs.width, target = dirtyAttrs.target, rel = dirtyAttrs.rel;
+        var font = dirtyAttrs.font, size = dirtyAttrs.size, link = dirtyAttrs.link, script = dirtyAttrs.script, list = dirtyAttrs.list, header = dirtyAttrs.header, align = dirtyAttrs.align, direction = dirtyAttrs.direction, indent = dirtyAttrs.indent, mentions = dirtyAttrs.mentions, mention = dirtyAttrs.mention, width = dirtyAttrs.width, height = dirtyAttrs.height, alt = dirtyAttrs.alt, target = dirtyAttrs.target, rel = dirtyAttrs.rel;
         var sanitizedAttrs = ['font', 'size', 'link', 'script', 'list', 'header', 'align',
-            'direction', 'indent', 'mentions', 'mention', 'width',
+            'direction', 'indent', 'mentions', 'mention', 'width', 'height', 'alt',
             'target', 'rel'
         ];
         booleanAttrs.forEach(function (prop) {
@@ -44,6 +44,12 @@ var OpAttributeSanitizer = (function () {
         }
         if (width) {
             cleanAttrs.width = width;
+        }
+        if (height) {
+            cleanAttrs.height = height;
+        }
+        if (alt) {
+            cleanAttrs.alt = alt;
         }
         if (list && OpAttributeSanitizer.IsValidList(list)) {
             cleanAttrs.list = list;

--- a/dist/commonjs/OpToHtmlConverter.js
+++ b/dist/commonjs/OpToHtmlConverter.js
@@ -169,6 +169,8 @@ var OpToHtmlConverter = (function () {
         var tagAttrs = classes.length ? [makeAttr('class', classes.join(' '))] : [];
         if (this.op.isImage()) {
             this.op.attributes.width && (tagAttrs = tagAttrs.concat(makeAttr('width', this.op.attributes.width)));
+            this.op.attributes.height && (tagAttrs = tagAttrs.concat(makeAttr('height', this.op.attributes.height)));
+            this.op.attributes.alt && (tagAttrs = tagAttrs.concat(makeAttr('alt', this.op.attributes.alt)));
             return tagAttrs.concat(makeAttr('src', this.op.insert.value));
         }
         if (this.op.isACheckList()) {

--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -11,6 +11,8 @@ interface IOpAttributes {
    font?: string | undefined,
    size?: string | undefined,
    width?: string | undefined,
+   height?: string | undefined,
+   alt?: string | undefined,
 
    link?: string | undefined,
    bold?: boolean | undefined,
@@ -62,11 +64,11 @@ class OpAttributeSanitizer {
       let colorAttrs = ['background', 'color'];
 
       let { font, size, link, script, list, header, align,
-         direction, indent, mentions, mention, width, target, rel
+         direction, indent, mentions, mention, width, height, alt, target, rel
       } = dirtyAttrs;
 
       let sanitizedAttrs = ['font', 'size', 'link', 'script', 'list', 'header', 'align',
-         'direction', 'indent', 'mentions', 'mention', 'width',
+         'direction', 'indent', 'mentions', 'mention', 'width', 'height', 'alt',
          'target', 'rel'
       ];
       booleanAttrs.forEach(function (prop: string) {
@@ -95,6 +97,14 @@ class OpAttributeSanitizer {
 
       if (width) {
          cleanAttrs.width = width;
+      }
+
+      if (height) {
+         cleanAttrs.height = height;
+      }
+
+      if (alt) {
+         cleanAttrs.alt = alt;
       }
 
       if (list && OpAttributeSanitizer.IsValidList(list)) {

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -232,6 +232,9 @@ class OpToHtmlConverter {
 
       if (this.op.isImage()) {
          this.op.attributes.width && (tagAttrs = tagAttrs.concat(makeAttr('width', this.op.attributes.width)));
+         this.op.attributes.height && (tagAttrs = tagAttrs.concat(makeAttr('height', this.op.attributes.height)));
+         this.op.attributes.alt && (tagAttrs = tagAttrs.concat(makeAttr('alt', this.op.attributes.alt)));
+
          return tagAttrs.concat(makeAttr('src', this.op.insert.value));
       }
 

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -600,6 +600,17 @@ describe('QuillDeltaToHtmlConverter', function () {
             assert.ok(v.indexOf('<my custom') > - 1);
          });
 
+         it('should render img with `width`, `height`, `alt` tags', function () {
+            var qdc = new QuillDeltaToHtmlConverter([
+               {
+                  insert: {image: 'https://www.w3schools.com/tags/smiley.gif'},
+                  attributes: {"alt":"2323","height":"33","width":"50"}
+               }
+            ]);
+            var html = qdc.convert();
+            assert.equal(html, '<p><img class="ql-image" width="50" height="33" alt="2323" src="https://www.w3schools.com/tags/smiley.gif"/></p>')
+         })
+
          it('should register and use callbacks if they are functions', function () {
             var c = new QuillDeltaToHtmlConverter([
                { insert: { video: "http" } }, { insert: 'aa' }]);


### PR DESCRIPTION
Previously converter ignores `alt` and `heigh` in the image, but it needs to be handled (https://github.com/readdle/quill/blob/1.3.6/formats/image.js#L5) 